### PR TITLE
Update scratchr2_settings.py

### DIFF
--- a/djangobb_forum/scratchr2_settings.py
+++ b/djangobb_forum/scratchr2_settings.py
@@ -27,5 +27,5 @@ DJANGOBB_SIGNATURE_MAX_LINES = 10
 DJANGOBB_SIGNATURE_MAX_LENGTH = 2000
 DJANGOBB_AUTHORITY_SUPPORT = False
 DJANGOBB_DEFAULT_TIME_ZONE = 0
-DJANGOBB_IMAGE_HOST_WHITELIST = r'(?:(?:tinypic|photobucket)\.com|imageshack\.us|modshare\.tk|(?:scratchr|wikipedia|wikimedia|modshare)\.org|\.edu|scratch-dach\.info)$'
+DJANGOBB_IMAGE_HOST_WHITELIST = r'(?:(?:tinypic|photobucket|cubeupload)\.com|imageshack\.us|modshare\.tk|(?:scratchr|wikipedia|wikimedia|modshare\.futuresight)\.org|\.edu|scratch-dach\.info)$'
 DJANGOBB_LANGUAGE_FILTER = r'(?i)\b(fugly|(\w*?)fuck(\w*?)|f(u|v|\*)?c?k(ing?)?|(\w*?)sh(i|1|l)t(\w*?)|cr(a|@|\*)p(per|ped|y)?|(bad|dumb|jack)?(a|@)ss(h(o|0)le|wipe)?|(bad|dumb|jack)?(a|@)rse(h(o|0)le|wipe)?|bastard|b(i|1|l|\*)?t?ch(e?s)?|cunt|cum|(god?)?dam(n|m)(it)?|douche(\w*?)|(new)?fag(got|gat)?|frig(gen|gin|ging)?|omfg|piss(\w*?)|porn|rape|retard|sex|s e x|shat|slut|tit|wh(o|0)re(\w*?)|wt(f|fh|h))(s|ed)?\b'


### PR DESCRIPTION
(Hopefully) adding Feature #1211 (Bugtracker): http://scratchexp.media.mit.edu/issues/1211
-> should add modshare.futuresight.org and cubeupload.com to the server white list for images in the forums

(well, I really hope this request-think works, as far as I know my first pull request wasn't in fact a real pull request or I don't know, I guess I don't understand Github yet^^. Well anyways, if this doesn't work, the code I want to suggest is here: https://github.com/LiFaytheGoblin/s2forums/blob/master/djangobb_forum/scratchr2_settings.py) 
