### PR TITLE
Fix "paste OS/version" button

### DIFF
--- a/djangobb_forum/static/djangobb_forum/js/markitup/sets/bbcode/set.js
+++ b/djangobb_forum/static/djangobb_forum/js/markitup/sets/bbcode/set.js
@@ -301,7 +301,8 @@ mySettings = {
                 'Size', 'Big', 'Small', 'Bulleted list', 'Numeric list',
                 'List item', 'Quotes', 'Smiles', 'Smile', 'Neutral', 'Sad',
                 'Big smile', 'Yikes', 'Wink', 'Hmm', 'Tongue', 'Lol', 'Mad',
-                'Roll', 'Cool', 'Clean', 'Preview']) > -1) {
+                'Roll', 'Cool', 'Clean', 'Preview',
+                'Paste browser / operating system versions']) > -1) {
             return;
         }
 


### PR DESCRIPTION
The "globe" button for pasting the user's browser/OS versions was added _after_ I did the scratchblocks menu, so I forgot to whitelist it. So my code unhelpfully adds [scratchblocks] tags around it.

Sorry!

As noticed here:
http://scratch.mit.edu/discuss/topic/20348/
