### PR TITLE
Fixed #1102

### DIFF
--- a/djangobb_forum/views.py
+++ b/djangobb_forum/views.py
@@ -531,6 +531,7 @@ def show_topic(request, topic_id, full=True):
                 'reply_form': reply_form,
                 })
 
+@login_required
 def show_unread_posts(request, topic_id, full=True):
     post = None
     user = request.user


### PR DESCRIPTION
Fixed #1102 (/unread/ when not logged in gives misleading message)
