### PR TITLE
ban spammer - new user deleted status for global user deletion

### DIFF
--- a/djangobb_forum/models.py
+++ b/djangobb_forum/models.py
@@ -810,7 +810,7 @@ class PostStatus(models.Model):
         pass
 
     @transition(
-        field=state, source=UNREVIEWED, target=USER_DELETED,
+        field=state, source=[UNREVIEWED, FILTERED_HAM, MARKED_HAM], target=USER_DELETED,
         save=True)
     def filter_user_deleted(self):
         """

--- a/djangobb_forum/tests/test_spam.py
+++ b/djangobb_forum/tests/test_spam.py
@@ -113,6 +113,25 @@ class ForumSpamTests(TestCase):
         self.assertEqual(
             self.post_status.post.topic.forum.name, forum_settings.SPAM_FORUM_NAME)
 
+    def test_transition_filter_user_deleted(self):
+        self.post_status = PostStatus.objects.create_for_post(self.test_post)
+        self.post_status.state = PostStatus.FILTERED_HAM
+        self.post_status.save()
+        self.post_status.filter_user_deleted()
+        self.assertEqual(PostStatus.USER_DELETED, self.post_status.state)
+        self.assertEqual(
+            self.post_status.post.topic.forum.name, forum_settings.SPAM_FORUM_NAME)
+
+    def test_transition_filter_user_undeleted(self):
+        self.post_status = PostStatus.objects.create_for_post(self.test_post)
+        self.post_status.state = PostStatus.FILTERED_HAM
+        self.post_status.save()
+        self.post_status.filter_user_deleted()
+        self.post_status.filter_user_undeleted()
+        self.assertEqual(PostStatus.UNREVIEWED, self.post_status.state)
+        self.assertNotEqual(
+            self.post_status.post.topic.forum.name, forum_settings.SPAM_FORUM_NAME)
+
     def test_review_new_posts(self):
         ham_post = Post.objects.create(
             topic=self.test_topic, user=self.user, body="Test ham content",


### PR DESCRIPTION
this created a new `PostStatus` state, `USER_DELETED`, which non spam posts can be set to on a user deletion. This allows for differentiation between user global deletion posts, and posts that are otherwise considered spam/deleted.

This also creates new manager methods to delete/undelete posts.
