### PR TITLE
Adding scrolling to postsignatures

### DIFF
--- a/djangobb_forum/static/djangobb_forum/themes/base.css
+++ b/djangobb_forum/static/djangobb_forum/themes/base.css
@@ -56,9 +56,11 @@ p, li {
 .box,
 .blockpost .box,
 .postleft,
-.postsignature,
 .postmsg {
 	overflow: hidden;
+}
+.postsignature {
+    overflow: auto;
 }
 #reply {
 	overflow: visible;


### PR DESCRIPTION
This is a small change to css, and it just allows you to scroll inside a user's signature. Nothing big. the box doesn't grow at all, and will remain the same size it was defined as.