### PR TITLE
CE-320 Privacy Enhanced Mode and sandbox for YouTube embeds

### DIFF
--- a/djangobb_forum/templates/djangobb_forum/youtube.html
+++ b/djangobb_forum/templates/djangobb_forum/youtube.html
@@ -13,7 +13,7 @@
                     <h4>{{ video_title }}</h4>
                 </div>
                 <div class="box-content">
-                    <iframe class="youtube-player" type="text/html" width="538" height="324" src="http://www.youtube-nocookie.com/embed/{{ video_id }}?fs=1&amp;rel=0&amp;autoplay=1&amp;showinfo=0" frameborder="0"></iframe>
+                    <iframe class="youtube-player" type="text/html" width="538" height="324" src="http://www.youtube-nocookie.com/embed/{{ video_id }}?fs=1&amp;rel=0&amp;autoplay=1&amp;showinfo=0" frameborder="0" sandbox="allow-scripts allow-presentation allow-popups allow-same-origin" allowfullscreen></iframe>
                 </div>
             </div>
         {% else %}

--- a/djangobb_forum/templates/djangobb_forum/youtube.html
+++ b/djangobb_forum/templates/djangobb_forum/youtube.html
@@ -13,7 +13,7 @@
                     <h4>{{ video_title }}</h4>
                 </div>
                 <div class="box-content">
-                    <iframe class="youtube-player" type="text/html" width="538" height="324" src="http://www.youtube.com/embed/{{ video_id }}?fs=1&amp;rel=0&amp;autoplay=1&amp;showinfo=0" frameborder="0"></iframe>
+                    <iframe class="youtube-player" type="text/html" width="538" height="324" src="http://www.youtube-nocookie.com/embed/{{ video_id }}?fs=1&amp;rel=0&amp;autoplay=1&amp;showinfo=0" frameborder="0"></iframe>
                 </div>
             </div>
         {% else %}


### PR DESCRIPTION
### Proposed Changes

This pull request turns on Privacy Enhanced Mode for the YouTube embed. It also adds the `sandbox` attribute.

### Reason for Changes

*TL;DR - enhance the privacy of the redirect.*

Privacy Enhanced Mode, as described [here](https://support.google.com/youtube/answer/171780#zippy=%2Cturn-on-privacy-enhanced-mode) by Google:

> The Privacy Enhanced Mode of the YouTube embedded player prevents the use of views of embedded YouTube content from influencing the viewer’s browsing experience on YouTube. This means that the view of a video shown in the Privacy Enhanced Mode of the embedded player will not be used to personalize the YouTube browsing experience, either within your Privacy Enhanced Mode embedded player or in the viewer’s subsequent YouTube viewing experience. 
>
> If ads are served on a video shown in the Privacy Enhanced Mode of the embedded player, those ads will likewise be non-personalized. In addition, the view of a video shown in the Privacy Enhanced Mode of the embedded player will not be used to personalize advertising shown to the viewer outside of your site or app.

The `sandbox` attributes also limits potential security risks - and in turn, privacy risks with it. If, for whatever reason, `youtube-nocookie.com` changes hands (which I seriously doubt), they can only access the minimum that is needed for the embed to fully function.

I know that this repository is no longer updated, but I also know that the forums themselves *are* still being updated. Please make this change :pray:



